### PR TITLE
chore: Remove parser overrides

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,26 +4,11 @@
   "bracketSpacing": true,
   "endOfLine": "lf",
   "jsxSingleQuote": false,
-  "parser": "typescript",
   "proseWrap": "always",
   "quoteProps": "as-needed",
   "semi": true,
   "singleAttributePerLine": true,
   "singleQuote": false,
   "tabWidth": 2,
-  "trailingComma": "all",
-  "overrides": [
-    {
-      "files": "*.json",
-      "options": {
-        "parser": "json"
-      }
-    },
-    {
-      "files": "*.yml",
-      "options": {
-        "parser": "yaml"
-      }
-    }
-  ]
+  "trailingComma": "all"
 }


### PR DESCRIPTION
The only reason I had to provider overrides was because I was specifying `parser: typescript` at the top level. Removing all of these lets Prettier infer the appropriate parser based on the file.