### PR TITLE
chore: Specify `prettier` as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "semantic-release": "23.0.0"
       },
       "peerDependencies": {
-        "prettier": "3.x"
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "@semantic-release/npm": "11.0.2",
         "prettier": "3.2.3",
         "semantic-release": "23.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "3.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "@semantic-release/npm": "11.0.2",
     "prettier": "3.2.3",
     "semantic-release": "23.0.0"
+  },
+  "peerDependencies": {
+    "prettier": "3.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "semantic-release": "23.0.0"
   },
   "peerDependencies": {
-    "prettier": "3.x"
+    "prettier": "^3.0.0"
   }
 }


### PR DESCRIPTION
This might technically require some kind of version bump, but I'm the only one using it and my projects already use a version `>= 3.0.0`.