### PR TITLE
docs: Use old syntax for extend code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ file:
 > `.prettierrc.js` file instead:
 >
 > ```js
-> import prettierConfig from "@anthony-j-castro/prettier-config";
+> const prettierConfig = require("@anthony-j-castro/prettier-config");
 >
-> export default {
+> module.exports = {
 >   ...prettierConfig,
 >   // Add or overwrite properties here
 > };


### PR DESCRIPTION
The newer syntax wasn't working in one of my projects and I had to use older syntax to get it to work.